### PR TITLE
Remove obsoleted master toolchain channel

### DIFF
--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -109,7 +109,7 @@ func routes(_ app: Application) throws {
             toolchainVersion = stableVersion();
         }
         let command = parameter.command ?? "swift"
-        let options = parameter.options ?? ((toolchainVersion == "nightly-master" || toolchainVersion == "nightly-main") ? "-Xfrontend -enable-experimental-concurrency" : "")
+        let options = parameter.options ?? (toolchainVersion == "nightly-main" ? "-Xfrontend -enable-experimental-concurrency" : "")
         let timeout = parameter.timeout ?? 60 // Default timeout is 60 seconds
         let color = parameter._color ?? false
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,9 +81,6 @@ services:
   swift-nightly-main:
     image: swiftlang/swift:nightly-main
     container_name: swift-nightly-main
-  swift-nightly-master:
-    image: swiftlang/swift:nightly-master
-    container_name: swift-nightly-master
   swift-nightly-5.4:
     image: swiftlang/swift:nightly-5.4
     container_name: swift-nightly-5.4


### PR DESCRIPTION
[`master` branch is now re-branched to `main`](https://forums.swift.org/t/updating-branch-names/40412), so the `nightly-master` won't be updated anymore.