### PR TITLE
Show completion item documentation in the suggestion panel

### DIFF
--- a/Public/js/app.js
+++ b/Public/js/app.js
@@ -107,10 +107,19 @@ export class App {
                   endLineNumber: end.line + 1,
                   endColumn: end.character + 1,
                 };
+                // sourcekit-lsp already ships documentation inline as a
+                // MarkupContent ({ kind, value }); pass it as a Markdown string
+                // so Monaco shows it in the suggestion details panel.
+                const documentation = item.documentation
+                  ? item.documentation.value !== undefined
+                    ? { value: item.documentation.value }
+                    : item.documentation
+                  : undefined;
                 return {
                   label: item.label,
                   kind: kind,
                   detail: item.detail,
+                  documentation: documentation,
                   filterText: item.filterText,
                   insertText: textEdit.newText,
                   insertTextRules: languageServer.insertTextRule(),


### PR DESCRIPTION
Completion items show only their `detail` (type) today; this also surfaces the documentation.

sourcekit-lsp already returns `documentation` inline on each completion item as a `MarkupContent` (`{ kind: "markdown", value }`) — verified against the live backend (e.g. `String.hasPrefix(_:)` ships its full doc comment). The frontend mapping just dropped it, so Monaco never showed the Quick Help / details panel.

This maps `item.documentation` to Monaco's `documentation` as a Markdown string. No backend change and no `completionItem/resolve` round-trip is needed — the data is already in the response.

Verified: webpack build passes.

> Follow-up to #1234 (merged). Pairs with the parameter-hints work in that PR and the backend `signatureHelp` (SwiftFiddle/swiftfiddle-lsp#358).

🤖 Generated with [Claude Code](https://claude.com/claude-code)