### PR TITLE
Fix share-image memory leak (disk cache) and harden silicon rendering

### DIFF
--- a/Sources/App/Controllers/ShareImage.swift
+++ b/Sources/App/Controllers/ShareImage.swift
@@ -1,15 +1,29 @@
 import Vapor
 
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Darwin)
+import Darwin
+#endif
+
 struct ShareImage {
+  /// Renders `code` to a PNG at `destination` using the `silicon` CLI.
+  ///
+  /// The image is written to a temporary file first and atomically moved into
+  /// place, so a crashed or killed render never leaves a partial image to be
+  /// served (or cached).
   @available(macOS 12.0.0, *)
-  static func generate(code: String) async throws -> Data? {
+  static func generate(code: String, to destination: URL) async throws {
     let process = Process()
     #if os(macOS)
     process.executableURL = URL(fileURLWithPath: "/opt/homebrew/bin/silicon")
     #else
     process.executableURL = URL(fileURLWithPath: "/home/linuxbrew/.linuxbrew/bin/silicon")
     #endif
-    let output = "\(UUID().uuidString).png"
+
+    let tempURL = destination
+      .deletingLastPathComponent()
+      .appendingPathComponent(".tmp-\(UUID().uuidString).png")
     process.arguments = [
       "--language", "swift",
       "--pad-horiz", "0",
@@ -17,30 +31,49 @@ struct ShareImage {
       "--font", "Source Han Code JP",
       "--no-window-controls",
       "--theme", "GitHub",
-      "--output", output,
+      "--output", tempURL.path,
     ]
 
     let standardInput = Pipe()
     process.standardInput = standardInput
-    process.standardOutput = Pipe()
-    process.standardError = Pipe()
+    // Discard silicon's stdout/stderr via the null device. Wiring up unread
+    // Pipes here is a latent deadlock: once silicon writes more than the ~64KB
+    // pipe buffer, it blocks on the write, the termination handler never fires,
+    // and the request (and the silicon process) hangs forever.
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+
+    defer { try? FileManager.default.removeItem(at: tempURL) }
 
     try standardInput.fileHandleForWriting.write(contentsOf: Data(code.utf8))
     try standardInput.fileHandleForWriting.close()
 
-    _ = try await withCheckedThrowingContinuation { (continuation) in
-      process.terminationHandler = { (process) in
+    let status = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int32, Error>) in
+      // Force-kill silicon if it hangs so it can't pin a request thread and its
+      // (font-rendering) memory indefinitely.
+      let killItem = DispatchWorkItem {
+        if process.isRunning {
+          kill(process.processIdentifier, SIGKILL)
+        }
+      }
+      DispatchQueue.global().asyncAfter(deadline: .now() + 20, execute: killItem)
+      process.terminationHandler = { process in
+        killItem.cancel()
         continuation.resume(returning: process.terminationStatus)
       }
       do {
         try process.run()
       } catch {
+        killItem.cancel()
         continuation.resume(throwing: error)
       }
     }
 
-    return try Data(contentsOf: URL(fileURLWithPath: output))
+    guard status == 0, FileManager.default.fileExists(atPath: tempURL.path) else {
+      throw Abort(.internalServerError, reason: "Failed to render share image")
+    }
+
+    try? FileManager.default.removeItem(at: destination)
+    try FileManager.default.moveItem(at: tempURL, to: destination)
   }
 }
-
-

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -82,9 +82,9 @@ func routes(_ app: Application) throws {
       code: parameter.code,
       swiftVersion: swiftVersion
     )
-    if let data = try? await ShareImage.generate(code: code) {
-      try? await req.cache.set("/\(id).png", to: data, expiresIn: .days(14))
-    }
+    // The share image is generated lazily on first request (and cached on
+    // disk) rather than eagerly here, so links that are never opened don't
+    // cost a silicon render or sit in memory.
     return [
       "swift_version": swiftVersion,
       "content": code,
@@ -140,24 +140,31 @@ func routes(_ app: Application) throws {
   }
 }
 
+private func shareImageCacheURL(_ app: Application, id: String) -> URL {
+  let directory = URL(fileURLWithPath: app.directory.workingDirectory)
+    .appendingPathComponent("Cache", isDirectory: true)
+    .appendingPathComponent("ShareImages", isDirectory: true)
+  try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+  return directory.appendingPathComponent("\(id).png")
+}
+
 private func makeImportResponse(_ req: Request, _ id: String, _ code: String, _ swiftVersion: String?) async throws -> Response {
   let path = req.url.path
   if path.hasSuffix(".png") {
-    if let data = try await req.cache.get(path, as: Data.self) {
-      return Response(
-        status: .ok,
-        headers: ["Content-Type": "image/png"],
-        body: Response.Body(buffer: ByteBuffer(data: data))
-      )
-    } else {
-      guard let data = try await ShareImage.generate(code: code) else { throw Abort(.notFound) }
-      try? await req.cache.set(path, to: data, expiresIn: .days(14))
-      return Response(
-        status: .ok,
-        headers: ["Content-Type": "image/png"],
-        body: Response.Body(buffer:  ByteBuffer(data: data))
-      )
+    // Cache the rendered share image on disk and stream it from there. The
+    // previous in-memory cache held every generated PNG for 14 days and, since
+    // Vapor's MemoryCache only evicts lazily on access, links whose image was
+    // never re-fetched leaked forever — the main driver of the OOM kills.
+    let cacheURL = shareImageCacheURL(req.application, id: id)
+    if !FileManager.default.fileExists(atPath: cacheURL.path) {
+      do {
+        try await ShareImage.generate(code: code, to: cacheURL)
+      } catch {
+        req.logger.error("Failed to generate share image: \(error)")
+        throw Abort(.notFound)
+      }
     }
+    return req.fileio.streamFile(at: cacheURL.path)
   } else {
     let version: String
     if let swiftVersion = swiftVersion {


### PR DESCRIPTION
Addresses the occasional OOM kills of the web server at the 512MB limit.

## Root cause
Share images (the OG PNGs at `/<id>.png`) were stored in Vapor's **in-memory** cache with a 14-day TTL. But `MemoryCache` only evicts lazily, on `get` of that exact key (verified in the Vapor source — there is no background sweep). A share whose image is never re-fetched therefore **leaks forever**. On top of that, `POST /shared_link` eagerly rendered and cached a PNG for *every* share, even ones never opened. Under sustained traffic the heap grew until the 512MB OOM.

So 512MB isn't really "too low" — without the leak this app's baseline is well under that. Raising the limit would only delay the OOM.

## Changes
- **Disk cache instead of heap.** The share image is generated lazily on the first `GET /<id>.png` and cached on disk under `Cache/ShareImages/`, then streamed back with `req.fileio.streamFile` (no full-image buffer on the heap). `POST /shared_link` no longer pre-renders. Heap no longer scales with the number of shares.
- **`ShareImage` hardening** (`ShareImage.swift`):
  - Render to a temp file and **atomically move** into place — a crashed/killed render never leaves a partial image to be served or cached.
  - **Discard silicon's stdout/stderr via the null device.** The previous code attached `Pipe()`s that were never read; once silicon wrote past the ~64KB pipe buffer it would block, the termination handler would never fire, and the request + process would hang forever.
  - **20s timeout → SIGKILL** so a hung render can't pin a request thread and its (font-rendering) memory.
  - Temp file always cleaned up (the old code leaked the output `.png` on disk).

## Verification
- `swift build` passes.
- Confirmed the exact silicon invocation (stdin code → `--output`, stdout/stderr to null) produces a valid PNG locally.

## Notes / follow-ups (not in this PR)
- The disk cache currently has no age-based cleanup. PNGs are small and disk ≫ the 512MB RAM cap, so it's far less urgent than the heap leak, but a periodic prune (or `tmpReaper`) would bound it.
- `POST /run` and `/runner/*/run` buffer the full proxied request/response in memory (bounded by concurrency, not a steady leak) — left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)