### PR TITLE
Run Package.resolved update on the production toolchain

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -6,24 +6,35 @@ on:
 
 jobs:
   run:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: SwiftyLab/setup-swift@latest
-      - name: Update Package.swift.json
+      # Resolve and build inside the same toolchain the app ships on
+      # (swift:6.3-jammy, see Dockerfile) so the generated Package.resolved is
+      # validated against production. The previous macOS Swift.org toolchain
+      # bundled a Foundation that lacks APIs used by transitive dependencies,
+      # causing spurious build failures.
+      - name: Update Package.swift.json and resolve packages
         run: |
           set -ex
 
-          tempdir=$(mktemp -d)
-          filename="Package.swift"
-          curl -sfL -o "$tempdir/$filename" https://raw.github.com/swiftfiddle/swiftfiddle-lsp/main/Resources/ProjectTemplate/$filename
-          swift package --package-path "$tempdir" dump-package > Resources/$filename.json
-      - name: Build
-        run: |
-          set -ex
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -e HOME=/tmp \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            swift:6.3-jammy \
+            bash -c '
+              set -ex
 
-          swift package update
-          swift build
+              tempdir=$(mktemp -d)
+              filename="Package.swift"
+              curl -sfL -o "$tempdir/$filename" https://raw.github.com/swiftfiddle/swiftfiddle-lsp/main/Resources/ProjectTemplate/$filename
+              swift package --package-path "$tempdir" dump-package > Resources/$filename.json
+
+              swift package update
+              swift build
+            '
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
## Problem

The weekly **Update Package.resolved** workflow (`spm.yml`) has been failing every run since early May 2026 (e.g. [run 27925733603](https://github.com/SwiftFiddle/swiftfiddle-web/actions/runs/27925733603), [27520002020](https://github.com/SwiftFiddle/swiftfiddle-web/actions/runs/27520002020)). The `Build` step dies with:

```
.build/checkouts/swift-configuration/Sources/Configuration/Providers/Files/FileProvider.swift:189:37:
error: value of type 'Data' has no member 'bytes'
```

so it never reaches **Create Pull Request** — dependency-update PRs have not been opened for ~7 weeks.

### Root cause

- `swift-configuration` is an **indirect** dependency: `vapor` → `async-http-client` → `apple/swift-configuration`. `async-http-client` added this dependency in **1.31.0**.
- The scheduled job runs `swift package update`, which resolves `swift-configuration` to **1.2.0**. That version uses `Data.bytes` in `FileProvider.swift`.
- The job installs the macOS Swift.org toolchain via `SwiftyLab/setup-swift@latest` (currently `swift-6.3.2-RELEASE`), whose **bundled Foundation does not expose `Data.bytes`** → compile error.
- This is environment-specific. The app ships on `swift:6.3-jammy` (see `Dockerfile`), and the **Test** workflow builds green there, so the resolved graph is fine for production — only the floating macOS Swift.org toolchain trips on it.

## Fix

Run the resolve/build inside the **same `swift:6.3-jammy` image the app deploys on**, so `Package.resolved` is validated against the real production toolchain instead of a floating macOS toolchain with a different Foundation. PR creation and automerge stay on the host runner where the `gh` CLI is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)