### PR TITLE
Fetch Package.swift template on host (swift image has no curl)

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -9,6 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      # Fetch the project template on the host runner; the swift:6.3-jammy
+      # image has no curl.
+      - name: Fetch Package.swift template
+        run: |
+          set -ex
+
+          mkdir -p .template
+          curl -sfL -o .template/Package.swift https://raw.github.com/swiftfiddle/swiftfiddle-lsp/main/Resources/ProjectTemplate/Package.swift
       # Resolve and build inside the same toolchain the app ships on
       # (swift:6.3-jammy, see Dockerfile) so the generated Package.resolved is
       # validated against production. The previous macOS Swift.org toolchain
@@ -27,14 +35,14 @@ jobs:
             bash -c '
               set -ex
 
-              tempdir=$(mktemp -d)
-              filename="Package.swift"
-              curl -sfL -o "$tempdir/$filename" https://raw.github.com/swiftfiddle/swiftfiddle-lsp/main/Resources/ProjectTemplate/$filename
-              swift package --package-path "$tempdir" dump-package > Resources/$filename.json
+              swift package --package-path .template dump-package > Resources/Package.swift.json
 
               swift package update
               swift build
             '
+      - name: Clean up template
+        if: always()
+        run: rm -rf .template
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
Follow-up to #1242.

After #1242 moved the resolve/build into the `swift:6.3-jammy` container, the workflow failed at the download step ([run 28041017642](https://github.com/SwiftFiddle/swiftfiddle-web/actions/runs/28041017642/job/83007012920)):

```
bash: line 6: curl: command not found
##[error]Process completed with exit code 127.
```

The `swift:6.3-jammy` image does not ship `curl`. This moves the template download back to the host runner (`ubuntu-latest`, which has `curl`) and keeps only the swift commands (`dump-package`, `swift package update`, `swift build`) inside the container.

Validated on the branch via `workflow_dispatch`: the host **Fetch Package.swift template** step succeeds and the run proceeds into the container build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)